### PR TITLE
add compatible client versions to config.py

### DIFF
--- a/argocd/apps/crab/crabserver/base/config/config.py
+++ b/argocd/apps/crab/crabserver/base/config/config.py
@@ -4,8 +4,6 @@ import socket
 import time
 import os
 
-# test configMapGenerator feature.
-
 myhost = socket.getfqdn().lower()
 
 conf = Configuration()
@@ -36,6 +34,8 @@ data.db = 'CRABServerAuth.dbconfig'
 data.s3 = 'CRABServerAuth.s3'
 data.s3_bucket = 'crabcache_dev'
 data.workflowManager = 'HTCondorDataWorkflow'
+# compatible client versions
+data.compatibleVersions = ["v3", "development"]
 
 data.extconfigurl = 'http://gitlab.cern.ch/crab3/CRAB3ServerConfig/raw/master/cmsweb-rest-config.json'
 

--- a/argocd/apps/crab/crabserver/overlays/preprod/config/config.py
+++ b/argocd/apps/crab/crabserver/overlays/preprod/config/config.py
@@ -38,6 +38,8 @@ data.backend = 'oracle'
 data.db = 'CRABServerAuth.dbconfig'
 data.s3 = 'CRABServerAuth.s3'
 data.workflowManager = 'HTCondorDataWorkflow'
+# compatible client versions
+data.compatibleVersions = ["v3", "development"]
 
 data.extconfigurl = 'http://gitlab.cern.ch/crab3/CRAB3ServerConfig/raw/master/cmsweb-rest-config.json'
 


### PR DESCRIPTION
Ciao Stefano, it should looks something like these. We will stick to branch `migrate-to-argocd` just for now.
P.S. after merged this, it will automatically propagates to all testX, preprod. 